### PR TITLE
Fetch sources per tenant

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,6 +10,7 @@ gem "manageiq-loggers", "~> 0.3.0"
 gem "manageiq-messaging", "~> 0.1.2"
 gem "optimist"
 gem "rake"
+gem "rest-client", "~>2.0"
 gem "sources-api-client", :git => "https://github.com/ManageIQ/sources-api-client-ruby", :branch => "master"
 
 group :test do

--- a/lib/sources/monitor/core/api_client.rb
+++ b/lib/sources/monitor/core/api_client.rb
@@ -15,8 +15,9 @@ module Sources
         end
 
         def internal_api_get(collection)
-          url = "#{ENV["SOURCES_SCHEME"] || "http"}://#{ENV["SOURCES_HOST"]}:#{ENV["SOURCES_PORT"]}"
-          JSON.parse(::RestClient.get("#{url}/internal/v1.0/#{collection}", identity(ORCHESTRATOR_TENANT)))
+          url = "#{SourcesApiClient.configure.scheme}://#{SourcesApiClient.configure.host}"
+          JSON.parse(::RestClient.get("#{url}/internal/v1.0/#{collection}",
+                                      identity(ORCHESTRATOR_TENANT).merge("Content-Type" => "application/json")))
         rescue ::RestClient::NotFound
           []
         end

--- a/spec/sources/monitor/availability_checker_spec.rb
+++ b/spec/sources/monitor/availability_checker_spec.rb
@@ -16,6 +16,10 @@ RSpec.describe(Sources::Monitor::AvailabilityChecker) do
     let(:openshift_topic)   { "platform.topological-inventory.operations-openshift" }
     let(:amazon_topic)      { "platform.topological-inventory.operations-amazon" }
 
+    let(:tenants_response) do
+      [{"external_tenant" => orchestrator_tenant}].to_json
+    end
+
     let(:source_types_response) do
       {
         "data" => [
@@ -86,6 +90,9 @@ RSpec.describe(Sources::Monitor::AvailabilityChecker) do
     end
 
     it "sends a request for an available source to the appropriate queue" do
+      stub_request(:get, "https://cloud.redhat.com/internal/v1.0/tenants")
+        .with(:headers => headers)
+        .to_return(:status => 200, :body => tenants_response, :headers => {})
       stub_request(:get, "https://cloud.redhat.com/api/sources/v1.0/source_types")
         .with(:headers => headers)
         .to_return(:status => 200, :body => source_types_response, :headers => {})
@@ -102,6 +109,9 @@ RSpec.describe(Sources::Monitor::AvailabilityChecker) do
     end
 
     it "sends a request for an unavailable source to the appropriate queue" do
+      stub_request(:get, "https://cloud.redhat.com/internal/v1.0/tenants")
+        .with(:headers => headers)
+        .to_return(:status => 200, :body => tenants_response, :headers => {})
       stub_request(:get, "https://cloud.redhat.com/api/sources/v1.0/source_types")
         .with(:headers => headers)
         .to_return(:status => 200, :body => source_types_response, :headers => {})


### PR DESCRIPTION
- Updated the source fetching logic so the sources are fetched based on the different tenants
- List of tenants is obtained using the internal sources-api API.

Best to view diffs with https://github.com/ManageIQ/sources-monitor/pull/1/files?w=1
