### PR TITLE
Enhanced specs for availability checks

### DIFF
--- a/spec/sources/monitor/availability_checker_spec.rb
+++ b/spec/sources/monitor/availability_checker_spec.rb
@@ -114,6 +114,12 @@ RSpec.describe(Sources::Monitor::AvailabilityChecker) do
         .to_return(:status => 202, :body => "", :headers => {})
 
       instance.check_sources
+
+      assert_requested(:post,
+                       "https://cloud.redhat.com/api/sources/v1.0/sources/#{available_source["id"]}/check_availability",
+                       :headers => headers.merge(instance.identity(available_source["tenant"])),
+                       :body    => "",
+                       :times   => 1)
     end
 
     it "sends a request for an unavailable source to the sources api" do
@@ -133,6 +139,12 @@ RSpec.describe(Sources::Monitor::AvailabilityChecker) do
         .to_return(:status => 202, :body => "", :headers => {})
 
       instance.check_sources
+
+      assert_requested(:post,
+                       "https://cloud.redhat.com/api/sources/v1.0/sources/#{unavailable_source["id"]}/check_availability",
+                       :headers => headers.merge(instance.identity(unavailable_source["tenant"])),
+                       :body    => "",
+                       :times   => 1)
     end
   end
 end


### PR DESCRIPTION

We removed the messaging client expectation of the publish_topic call and we needed to replace that guarantee, so adding the post assertion of the check_availability action.