### PR TITLE
Updated sources-api calls to be identified as org_admin calls.

### DIFF
--- a/lib/sources/monitor/core/api_client.rb
+++ b/lib/sources/monitor/core/api_client.rb
@@ -23,7 +23,7 @@ module Sources
         end
 
         def identity(external_tenant)
-          { "x-rh-identity" => Base64.strict_encode64({ "identity" => { "account_number" => external_tenant }}.to_json) }
+          { "x-rh-identity" => Base64.strict_encode64({ "identity" => { "account_number" => external_tenant, "user" => { "is_org_admin" => true }}}.to_json) }
         end
 
         PAGED_SIZE = 1000

--- a/spec/sources/monitor/availability_checker_spec.rb
+++ b/spec/sources/monitor/availability_checker_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe(Sources::Monitor::AvailabilityChecker) do
     let(:orchestrator_tenant) { "system_orchestrator" }
     let(:identity) do
       { "x-rh-identity" => Base64.strict_encode64(
-        { "identity" => { "account_number" => orchestrator_tenant } }.to_json
+        { "identity" => { "account_number" => orchestrator_tenant, "user" => { "is_org_admin" => true } } }.to_json
       )}
     end
     let(:headers) { {"Content-Type" => "application/json"}.merge(identity) }


### PR DESCRIPTION

- identity header used now have the is_org_admin flag set as true for the sources-api calls.