### PR TITLE
Enable test coverage and rubocop usage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,11 @@ rvm:
   - 2.5.7
   - 2.6.5
 before_install:
+- gem install bundler
+before_script:
 - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64
   > ./cc-test-reporter
 - chmod +x ./cc-test-reporter
 - "./cc-test-reporter before-build"
-- gem install bundler -v 2.0.1
+after_script:
+- "./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT"

--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,6 @@ plugin 'bundler-inject', '~> 1.1'
 require File.join(Bundler::Plugin.index.load_paths("bundler-inject")[0], "bundler-inject") rescue nil
 $LOAD_PATH.push(File.expand_path("lib", __dir__))
 
-gem "bundler",            "~> 2.0"
 gem "cloudwatchlogger",   "~> 0.2"
 gem "manageiq-loggers",   "~> 0.4.2"
 gem "manageiq-messaging", "~> 0.1.2"
@@ -13,8 +12,10 @@ gem "rake",               "~> 13.0.0"
 gem "rest-client",        "~>2.0"
 gem "sources-api-client", "~> 1.0"
 
-group :test do
+group :test, :development do
   gem "rspec"
-  gem "simplecov"
+  gem 'rubocop', '~>0.69.0', :require => false
+  gem 'rubocop-performance', '~>1.3',    :require => false
+  gem 'simplecov', '= 0.17.1'
   gem "webmock"
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,6 +2,11 @@ require "bundler/setup"
 require "webmock/rspec"
 require "sources/monitor"
 
+if ENV['CI']
+  require 'simplecov'
+  SimpleCov.start
+end
+
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure
   config.example_status_persistence_file_path = ".rspec_status"


### PR DESCRIPTION
When I added `cc-test-reporter` to the `.travis.yml` file I did not check if it was fully enabled, so fixing that here.

CodeClimate reports that it does not support SimpleCov 0.18 yet so locking it down to the same version the other repos use.  (See [Configuring Test Coverage: Supported Languages and Formats](https://docs.codeclimate.com/docs/configuring-test-coverage#supported-languages-and-formats))

Finally, I wasn't sure why `bundler` was specified in the `Gemfile` or locked to "~> 2.0". 
```diff
- gem "bundler",            "~> 2.0"
```
Having this setting also required `gem install bundler -v 2.0.1` in `.travis.yml`.  I removed the reference in `Gemfile` and switch to `gem install bundler` which matches all the other repos now and everything seems to be working.

@slemrmartin Do you know if there was a reason behind this setting?