### PR TITLE
Pin CloudWatchLogger to 0.2.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ plugin 'bundler-inject', '~> 1.1'
 require File.join(Bundler::Plugin.index.load_paths("bundler-inject")[0], "bundler-inject") rescue nil
 $LOAD_PATH.push(File.expand_path("lib", __dir__))
 
-gem "cloudwatchlogger",   "~> 0.2"
+gem "cloudwatchlogger",   "~> 0.2.1"
 gem "manageiq-loggers",   "~> 0.4.2"
 gem "manageiq-messaging", "~> 0.1.2"
 gem "optimist"


### PR DESCRIPTION
**Issue**: https://github.com/RedHatInsights/topological_inventory-persister/issues/70

CloudWatchLogger 0.3.0 is not compatible