### PR TITLE
Update travis URL in README file.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Sources::Monitor
 
-[![Build Status](https://api.travis-ci.org/RedHatInsights/sources-monitor.svg)](https://travis-ci.org/RedHatInsights/sources-monitor)
+[![Build Status](https://api.travis-ci.com/RedHatInsights/sources-monitor.svg)](https://travis-ci.com/RedHatInsights/sources-monitor)
 [![Maintainability](https://api.codeclimate.com/v1/badges/f9bf0e45949cd681cee1/maintainability)](https://codeclimate.com/github/RedHatInsights/sources-monitor/maintainability)
 [![Test Coverage](https://api.codeclimate.com/v1/badges/f9bf0e45949cd681cee1/test_coverage)](https://codeclimate.com/github/RedHatInsights/sources-monitor/test_coverage)
 [![security](https://hakiri.io/github/RedHatInsights/sources-monitor/master.svg)](https://hakiri.io/github/RedHatInsights/sources-monitor/master)


### PR DESCRIPTION
Travis migrated from URL travis-ci.org -> travis-ci.com.

This PR is based on RedHatInsights/topological_inventory-api#334 issue.