### PR TITLE
Excluding tenants request

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,7 @@ gem "manageiq-messaging",    "~> 1.0.0"
 gem "optimist"
 gem "rake",                  "~> 13.0.0"
 gem "rest-client",           "~>2.0"
-gem "sources-api-client",    "~> 1.0"
+gem "sources-api-client",    "~> 3.0"
 
 group :test, :development do
   gem "rspec"


### PR DESCRIPTION
Sources requests from internal API don't need preceding tenant request 

- [x] **depends on** https://github.com/RedHatInsights/sources-api/pull/394

---

[RHCLOUD-14215](https://issues.redhat.com/browse/RHCLOUD-14215)