### PR TITLE
Set log level for container logger

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ $LOAD_PATH.push(File.expand_path("lib", __dir__))
 # Parser for Clowder config in ENV['ACG_CONFIG'] path
 gem "activesupport",         "~> 5.2", ">= 5.2.4.3"
 gem 'clowder-common-ruby',   "~> 0.2.1"
-gem "insights-loggers-ruby", "~> 0.1.9"
+gem "insights-loggers-ruby", "~> 0.1.10"
 gem "manageiq-messaging",    "~> 1.0.0"
 gem "optimist"
 gem "rake",                  "~> 13.0.0"

--- a/lib/sources/monitor/core/logging.rb
+++ b/lib/sources/monitor/core/logging.rb
@@ -12,7 +12,7 @@ module Sources
       if ENV['LOG_HANDLER'] == "haberdasher"
         "Insights::Loggers::StdErrLogger"
       else
-        "ManageIQ::Loggers::CloudWatch"
+        "Insights::Loggers::CloudWatch"
       end
     end
 


### PR DESCRIPTION
WIP reason:
- [x] https://github.com/RedHatInsights/insights-loggers-ruby/pull/1

- Use new version of [insights-loggers-ruby](https://github.com/RedHatInsights/insights-loggers-ruby) which will be created after https://github.com/RedHatInsights/insights-loggers-ruby/pull/1
- Use `Insights::Loggers::CloudWatch` as logger
  - log levels could be set by `ENV['LOG_LEVEL']` for CloudWatch  logger or
  - log levels could be set by `ENV['CONTAINER_LOG_LEVEL']` for container logger
 

